### PR TITLE
Use field reification to save space.

### DIFF
--- a/src/hx/delegates/DelegateBuilder.hx
+++ b/src/hx/delegates/DelegateBuilder.hx
@@ -93,19 +93,10 @@ final class DelegateBuilder {
                 name: className,
                 kind: TDClass(superPath.typePath, null, false, true, false),
                 fields: fields,
-                meta: [{name:':access', params: [convertToEField(module)], pos: Context.currentPos()}]
+                meta: [{name:':access', params: [macro {$p{module.split('.')};}], pos: Context.currentPos()}]
             });
         }
         return {pack: typePath, name: className};
-    }
-
-    private static function convertToEField(path : String) : Expr {
-        var patharray = path.split('.');
-        var current = {pos: Context.currentPos(), expr: EConst(CIdent(patharray[0]))};
-        for(i in 1...patharray.length) {
-            current = {pos: Context.currentPos(), expr: EField(current, patharray[i])};
-        }
-        return current;
     }
 
     private static function resolveSuperType(func : Function) : SuperType {


### PR DESCRIPTION
`convertToEField` essentially re-implements a feature from the standard library, so I figure we should use that if possible.