### PR TITLE
Use Eval to run tests, instead of Neko.

### DIFF
--- a/unit/test.hxml
+++ b/unit/test.hxml
@@ -2,4 +2,4 @@
 -main Main
 -lib haxe-delegates
 -lib utest
--x Main
+--run Main


### PR DESCRIPTION
[Eval](https://haxe.org/blog/eval/) is Haxe's new(ish) interpreter, with various improvements over Neko that barely matter for such a small test suite. Mainly I'm suggesting this because Neko is no longer maintained.